### PR TITLE
feat(simulator): phase1-04b — ODE RHS wrapper on Stage 6 (no transport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ docs/papers/*
 docs/figures/*
 SPRINTS.md
 docs/mass_balances/oxygen-balance-verification.pdf
+docs/theory/*
 
 # --- IDEs & OS ---
 .vscode/

--- a/docs/SIMULATOR_MATH.md
+++ b/docs/SIMULATOR_MATH.md
@@ -564,6 +564,7 @@ Each map in the pipeline (**totals** $\to$ **charge residual** $\to$ **pH** $\to
 | $\boldsymbol{\rho}_{\mathrm{bio}}$ | [`src/bioprocess_twin/models/kinetics.py`](../src/bioprocess_twin/models/kinetics.py) (`calculate_rates`, `EnvConditions`) |
 | $\boldsymbol{\rho}_{\mathrm{gas}}$, Henry, k_La scaling | [`src/bioprocess_twin/models/gas_transfer.py`](../src/bioprocess_twin/models/gas_transfer.py) (`calculate_gas_transfer`) |
 | Stage 6 liquid RHS assembler | [`src/bioprocess_twin/simulator/liquid_rhs.py`](../src/bioprocess_twin/simulator/liquid_rhs.py) (`evaluate_liquid_rhs`, `AlbaLiquidRhsResult`) |
+| ODE vector field wrapper (Sprint 4.1 / 04b): $(t,\mathbf{y})\mapsto \mathrm{d}\mathbf{C}/\mathrm{d}t$ with diel forcing, no transport | [`src/bioprocess_twin/simulator/liquid_ode_rhs.py`](../src/bioprocess_twin/simulator/liquid_ode_rhs.py) (`evaluate_liquid_ode_rhs`, `LiquidOdeRhsProblem`, `make_liquid_rhs`) |
 | Speciation, charge residual, $\mathcal{H}$ | [`src/bioprocess_twin/models/chemistry.py`](../src/bioprocess_twin/models/chemistry.py) (`solve_pH`, helpers) |
 | Facade $\to$ pH + gas bundle | [`src/bioprocess_twin/models/hydrochemistry_api.py`](../src/bioprocess_twin/models/hydrochemistry_api.py) (`hydrochemistry_step`) |
 | Optional extended $\mathbf{S}$, closures | [`src/bioprocess_twin/models/stoichiometry_closure.py`](../src/bioprocess_twin/models/stoichiometry_closure.py) |
@@ -729,6 +730,8 @@ flowchart TD
 ### F.1 Stage 6 implementation in [`liquid_rhs.py`](../src/bioprocess_twin/simulator/liquid_rhs.py)
 
 The function **`evaluate_liquid_rhs`** implements one evaluation of the liquid-phase RHS: it does **not** advance time or sample a long horizon; a time integrator (Sprint 4 scope) would call it repeatedly. Internally it uses **`hydrochemistry_step`**, which chains SI.6 **solve pH** and SI.7 **gas transfer**; then it aligns **`EnvConditions.pH`** to the solved pH for **`calculate_rates`**, stacks **22** process rates, and forms **dC/dt** with the fixed **22×17** matrix from **`get_petersen_matrix_with_gas_transfer`**. (Diagnostics also run **`speciate_from_alba_totals`** for species reporting; that path is not drawn below.)
+
+For **`scipy.integrate.solve_ivp`**, the thin entry point **`evaluate_liquid_ode_rhs`** in [`liquid_ode_rhs.py`](../src/bioprocess_twin/simulator/liquid_ode_rhs.py) maps clock time and $\mathbf{y}$ to **`EnvConditions`** via **`DielForcingSchedule`** (Fig. 1–based forcing) and returns the same **17**-component derivative as **`evaluate_liquid_rhs`**, without CSTR transport (added later in Sprint 4.3).
 
 ```mermaid
 flowchart TD

--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -4,6 +4,7 @@ This document is a log of the development process of the project. It is used to 
 
 ## Index
 
+- [2026-04-30 - Sprint phase1-04b: ODE RHS wrapper (`evaluate_liquid_ode_rhs`, no transport)](#devlog-20260430-p104b-ode-rhs)
 - [2026-04-25 - Sprint phase1-04a prep: Fig. 1 daily forcing (T, PAR, evaporation)](#devlog-20260425-fig1-daily-forcing)
 - [2026-04-25 - ALBA Casagli et al. (2021) Article Review](#devlog-20260425-p103-alba-paper-reactor)
 - [2026-04-23 - Sprint phase1-03.5: Stage 6 liquid RHS, 22×17 assembly, and 'evaluate_liquid_rhs'](#devlog-20260423-p1035-stage6-liquid-rhs)
@@ -26,6 +27,24 @@ This document is a log of the development process of the project. It is used to 
 
 ---
 
+<a id="devlog-20260430-p104b-ode-rhs"></a>
+
+## [2026-04-30] - Sprint phase1-04b: ODE RHS wrapper (`evaluate_liquid_ode_rhs`, no transport)
+
+### Context & Goals
+Deliver **Sprint 4.2 / issue `phase1-04b`**: a callable **$\mathbf{f}(\mathbf{C}, t)$** in SciPy shape **`rhs(t, y)`** that pins the liquid ODE to **17** states via **`evaluate_liquid_rhs`**, with **temperature and irradiance** coming from **`DielForcingSchedule`** (phase1-04a). **No** CSTR dilution term yet (phase1-04c).
+
+### Technical Implementation
+- **`src/bioprocess_twin/simulator/liquid_ode_rhs.py`:** frozen **`LiquidOdeRhsProblem`** (schedule, `initial_ph` / `placeholder_ph_for_env` default 7, passthrough kwargs for gas and pH solver); **`evaluate_liquid_ode_rhs(t_hours, y, problem=...)`** and **`make_liquid_rhs`** for `solve_ivp`.
+- **`src/bioprocess_twin/simulator/liquid_rhs.py`:** public **`state_vector_from_y`** (SI-length 17 `ndarray` to **`StateVector`**).
+- **`tests/unit/test_liquid_ode_rhs.py`:** numeric parity vs direct **`evaluate_liquid_rhs`**, shape/finiteness, closure factory, day vs night forcing sanity, bad length error.
+- **`docs/SIMULATOR_MATH.md`:** Appendix C map row + F.1 pointer to **`liquid_ode_rhs.py`**.
+
+### Next Steps
+- **phase1-04c:** add **$(Q/V)(\mathbf{C}_\mathrm{in}-\mathbf{C})$** on top of this RHS; **phase1-04d:** stiff integrator driver.
+
+---
+
 <a id="devlog-20260425-fig1-daily-forcing"></a>
 
 ## [2026-04-25] - Sprint phase1-04a prep: Fig. 1 daily forcing for simulator environmental drivers
@@ -41,7 +60,8 @@ Prepare **tabular and smooth diel series** consistent with **Casagli et al. (202
 - **Schedule API (`phase1-04a`):** `src/bioprocess_twin/forcing/diel_forcing_schedule.py` exposes `DielForcingSchedule` with `at` / `at_many` for dense grids, optional **RH, wind, rain, evaporation override,** and **inflow Q** as `None`, constants, or callables; `to_env_conditions(sample, ph=...)` maps kinetic inputs into **`EnvConditions`** (pH remains caller-supplied). Package exports live in `src/bioprocess_twin/forcing/__init__.py`.
 
 ### Next Steps
-- Wire **`DielForcingSchedule`** into **`phase1-04b`** (RHS wrapper): build **`EnvConditions`** along trajectories; keep optional hydrology fields for **`phase1-04c`** transport.
+- **phase1-04b** (done 2026-04-30): ODE RHS wrapper **`evaluate_liquid_ode_rhs`** / **`LiquidOdeRhsProblem`** — see dedicated DEVLOG entry above.
+- **phase1-04c:** add **$(Q/V)(\mathbf{C}_\mathrm{in}-\mathbf{C})$** and hydraulics; optional hydrology fields on **`ForcingSample`** remain for that milestone.
 
 ---
 

--- a/src/bioprocess_twin/simulator/__init__.py
+++ b/src/bioprocess_twin/simulator/__init__.py
@@ -1,17 +1,27 @@
 """Simulation orchestration utilities."""
 
+from bioprocess_twin.simulator.liquid_ode_rhs import (
+    LiquidOdeRhsProblem,
+    evaluate_liquid_ode_rhs,
+    make_liquid_rhs,
+)
 from bioprocess_twin.simulator.liquid_rhs import (
     AlbaLiquidRhsResult,
     BiomassConcentrations,
     EnvironmentalSnapshot,
     LiquidRhsDiagnostics,
     evaluate_liquid_rhs,
+    state_vector_from_y,
 )
 
 __all__ = [
     "AlbaLiquidRhsResult",
     "BiomassConcentrations",
     "EnvironmentalSnapshot",
+    "LiquidOdeRhsProblem",
     "LiquidRhsDiagnostics",
+    "evaluate_liquid_ode_rhs",
     "evaluate_liquid_rhs",
+    "make_liquid_rhs",
+    "state_vector_from_y",
 ]

--- a/src/bioprocess_twin/simulator/liquid_ode_rhs.py
+++ b/src/bioprocess_twin/simulator/liquid_ode_rhs.py
@@ -1,0 +1,72 @@
+"""ODE-sized liquid RHS: Stage 6 only, with diel forcing (phase1-04a) and no transport (04c)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+from bioprocess_twin.forcing.diel_forcing_schedule import DielForcingSchedule, to_env_conditions
+from bioprocess_twin.models.chemistry import AlbaDissociationConstantsRef, AlbaDissociationEnthalpy, PHSolverOptions
+from bioprocess_twin.models.gas_transfer import GasTransferConditions
+from bioprocess_twin.models.kinetic_parameters import KineticParameters
+
+from .liquid_rhs import evaluate_liquid_rhs, state_vector_from_y
+
+
+@dataclass(frozen=True, slots=True)
+class LiquidOdeRhsProblem:
+    """
+    Immutable bundle for evaluate_liquid_ode_rhs.
+
+    Time: t_hours passed to the RHS is hours of day (clock time). Values outside
+    [0,24) are reduced modulo 24 inside DielForcingSchedule.at (same convention as forcing).
+    """
+
+    schedule: DielForcingSchedule
+    initial_ph: float = 7.0
+    placeholder_ph_for_env: float = 7.0
+    kinetic_parameters: KineticParameters | None = None
+    theta_kla: float | None = None
+    gas_conditions: GasTransferConditions | None = None
+    delta_cat_an_mol_per_m3: float = 0.0
+    options: PHSolverOptions | None = None
+    k_ref: AlbaDissociationConstantsRef | None = None
+    dh: AlbaDissociationEnthalpy | None = None
+
+
+def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOdeRhsProblem) -> np.ndarray:
+    """
+    SciPy-style vector field: dy/dt in g m⁻³ d⁻¹, shape (N_STATE,).
+
+    Builds EnvConditions from problem.schedule.at(t_hours) and
+    to_env_conditions(..., ph=problem.placeholder_ph_for_env). Solved pH inside
+    evaluate_liquid_rhs still comes from SI.6 charge balance (initial_ph is only the
+    solver guess).
+    """
+    st = state_vector_from_y(y)
+    sample = problem.schedule.at(t_hours)
+    env = to_env_conditions(sample, ph=problem.placeholder_ph_for_env)
+    out = evaluate_liquid_rhs(
+        st,
+        env,
+        kinetic_parameters=problem.kinetic_parameters,
+        theta_kla=problem.theta_kla,
+        gas_conditions=problem.gas_conditions,
+        delta_cat_an_mol_per_m3=problem.delta_cat_an_mol_per_m3,
+        initial_ph=problem.initial_ph,
+        options=problem.options,
+        k_ref=problem.k_ref,
+        dh=problem.dh,
+    )
+    return np.asarray(out.dcdt_g_m3_d, dtype=np.float64).ravel()
+
+
+def make_liquid_rhs(problem: LiquidOdeRhsProblem) -> Callable[[float, np.ndarray], np.ndarray]:
+    """Return rhs(t, y) closed over problem for use with solve_ivp."""
+
+    def rhs(t_hours: float, y: np.ndarray) -> np.ndarray:
+        return evaluate_liquid_ode_rhs(t_hours, y, problem=problem)
+
+    return rhs

--- a/src/bioprocess_twin/simulator/liquid_rhs.py
+++ b/src/bioprocess_twin/simulator/liquid_rhs.py
@@ -81,8 +81,8 @@ class AlbaLiquidRhsResult:
     diagnostics: LiquidRhsDiagnostics
 
 
-def _as_state_vector(state: StateVector | np.ndarray) -> StateVector:
-    """Normalize user state input to StateVector in SI 17-state layout."""
+def state_vector_from_y(state: StateVector | np.ndarray) -> StateVector:
+    """Coerce SI-layout length-17 ``ndarray`` (or ``StateVector``) to ``StateVector``."""
     if isinstance(state, StateVector):
         return state
     arr = np.asarray(state, dtype=np.float64).ravel()
@@ -125,7 +125,7 @@ def evaluate_liquid_rhs(
     - compute rho_bio (19) and rho_gas (3)
     - assemble rho_full (22) and dC/dt (17) via S_full^T @ rho_full
     """
-    st = _as_state_vector(state)
+    st = state_vector_from_y(state)
     params = kinetic_parameters if kinetic_parameters is not None else default_alba()
     theta_value = float(theta_kla) if theta_kla is not None else float(params.theta_kla)
 
@@ -158,9 +158,7 @@ def evaluate_liquid_rhs(
     )
     rho_full = np.concatenate((rho_bio, rho_gas))
     if rho_full.size != N_PROCESSES_WITH_GAS_TRANSFER:
-        raise RuntimeError(
-            f"rho_full must have length {N_PROCESSES_WITH_GAS_TRANSFER}, got {rho_full.size}"
-        )
+        raise RuntimeError(f"rho_full must have length {N_PROCESSES_WITH_GAS_TRANSFER}, got {rho_full.size}")
     if rho_bio.size != N_PROCESSES:
         raise RuntimeError(f"rho_bio must have length {N_PROCESSES}, got {rho_bio.size}")
 

--- a/tests/unit/test_liquid_ode_rhs.py
+++ b/tests/unit/test_liquid_ode_rhs.py
@@ -1,0 +1,93 @@
+"""Tests for ODE-sized liquid RHS wrapper (phase1-04b)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bioprocess_twin.core.state import StateVector
+from bioprocess_twin.forcing import DielForcingSchedule, to_env_conditions
+from bioprocess_twin.models.stoichiometry import N_STATE
+from bioprocess_twin.simulator import (
+    LiquidOdeRhsProblem,
+    evaluate_liquid_ode_rhs,
+    evaluate_liquid_rhs,
+    make_liquid_rhs,
+    state_vector_from_y,
+)
+
+
+def _stage6_state() -> StateVector:
+    """Same representative state as ``test_liquid_rhs_stage6`` (avoid cross-test imports)."""
+    return StateVector(
+        X_ALG=80.0,
+        X_AOB=25.0,
+        X_NOB=22.0,
+        X_H=120.0,
+        X_S=50.0,
+        X_I=35.0,
+        S_S=40.0,
+        S_I=20.0,
+        S_IC=35.0,
+        S_ND=5.0,
+        S_NH=12.0,
+        S_NO2=1.2,
+        S_NO3=5.5,
+        S_N2=8.0,
+        S_PO4=4.0,
+        S_O2=7.0,
+        S_H2O=0.0,
+    )
+
+
+def test_evaluate_liquid_ode_rhs_matches_direct_stage6() -> None:
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 10.5
+    schedule = DielForcingSchedule(season="summer")
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    env = to_env_conditions(schedule.at(t_hours), ph=problem.placeholder_ph_for_env)
+    direct = evaluate_liquid_rhs(st, env, initial_ph=problem.initial_ph)
+    wrapped = evaluate_liquid_ode_rhs(t_hours, y, problem=problem)
+    assert wrapped.shape == (N_STATE,)
+    np.testing.assert_allclose(wrapped, direct.dcdt_g_m3_d, rtol=1e-12, atol=1e-12)
+
+
+def test_evaluate_liquid_ode_rhs_finite_and_state_vector_from_y() -> None:
+    st = _stage6_state()
+    y = st.to_array()
+    problem = LiquidOdeRhsProblem(schedule=DielForcingSchedule(season="autumn"))
+    dydt = evaluate_liquid_ode_rhs(6.0, y, problem=problem)
+    assert dydt.shape == (N_STATE,)
+    assert np.all(np.isfinite(dydt))
+    assert state_vector_from_y(y).to_array().shape == (N_STATE,)
+
+
+def test_make_liquid_rhs_closure() -> None:
+    st = _stage6_state()
+    y = st.to_array()
+    problem = LiquidOdeRhsProblem(schedule=DielForcingSchedule(season="winter"))
+    rhs = make_liquid_rhs(problem)
+    a = rhs(12.0, y)
+    b = evaluate_liquid_ode_rhs(12.0, y, problem=problem)
+    np.testing.assert_allclose(a, b)
+
+
+def test_different_clock_hours_change_forcing_and_dcdt() -> None:
+    """Day vs night irradiance (summer) should not yield identical derivatives."""
+    st = _stage6_state()
+    y = st.to_array()
+    schedule = DielForcingSchedule(season="summer")
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    s_noon = schedule.at(14.0)
+    s_night = schedule.at(22.0)
+    assert s_noon.irradiance_umol_m2_s > s_night.irradiance_umol_m2_s
+    d_noon = evaluate_liquid_ode_rhs(14.0, y, problem=problem)
+    d_night = evaluate_liquid_ode_rhs(22.0, y, problem=problem)
+    assert not np.allclose(d_noon, d_night, rtol=0.0, atol=0.0)
+
+
+def test_wrong_state_length_raises() -> None:
+    problem = LiquidOdeRhsProblem(schedule=DielForcingSchedule(season="spring"))
+    with pytest.raises(ValueError, match="length"):
+        evaluate_liquid_ode_rhs(0.0, np.zeros(5), problem=problem)


### PR DESCRIPTION
## Summary
Implements **Sprint 4.2 / phase1-04b**: a SciPy-shaped **`rhs(t, y)`** returning **dC/dt** with **17** liquid states by calling **`evaluate_liquid_rhs`**, with **temperature and irradiance** from **`DielForcingSchedule`** (phase1-04a). **No** CSTR dilution term (phase1-04c).

## Changes
- New **`liquid_ode_rhs.py`**: **`LiquidOdeRhsProblem`**, **`evaluate_liquid_ode_rhs`**, **`make_liquid_rhs`** (contract: **`t`** is **clock hours**, consistent with **`DielForcingSchedule.at`**).
- **`state_vector_from_y`** in **`liquid_rhs.py`**; re-exports in **`simulator/__init__.py`**.
- **`tests/unit/test_liquid_ode_rhs.py`**: numeric parity vs direct Stage 6 call, shape/finiteness, day vs night forcing sanity.
- Docs: **`DEVLOG`**, **`SIMULATOR_MATH`** (cross-link to the new module).

## How to verify
`uv run pytest tests/unit/test_liquid_ode_rhs.py -v`