### PR TITLE
feat(simulator): startup batch water balance and phase1-04c CSTR transport (A/B/C)

### DIFF
--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -4,6 +4,7 @@ This document is a log of the development process of the project. It is used to 
 
 ## Index
 
+- [2026-05-02 - Sprint phase1-04c: Startup batch integration (SI 17 + evaporation / volume ODE)](#devlog-20260502-p104c-startup-batch)
 - [2026-04-30 - Sprint phase1-04b: ODE RHS wrapper (`evaluate_liquid_ode_rhs`, no transport)](#devlog-20260430-p104b-ode-rhs)
 - [2026-04-25 - Sprint phase1-04a prep: Fig. 1 daily forcing (T, PAR, evaporation)](#devlog-20260425-fig1-daily-forcing)
 - [2026-04-25 - ALBA Casagli et al. (2021) Article Review](#devlog-20260425-p103-alba-paper-reactor)
@@ -24,6 +25,23 @@ This document is a log of the development process of the project. It is used to 
 - [2026-03-12 - Phase 1: Technical Specification & Architecture Definition](#devlog-20260312-phase1-spec-arch)
 - [2026-03-12 - Phase 1: ALBA Model Analysis & Data Digitization](#devlog-20260312-phase1-alba-digitization)
 - [2026-03-10 - Phase 0: Project Initialization and Foundation](#devlog-20260310-phase0-init)
+
+---
+
+<a id="devlog-20260502-p104c-startup-batch"></a>
+
+## [2026-05-02] - Sprint phase1-04c: Startup batch integration (SI 17 + evaporation / volume ODE)
+
+### Context & Goals
+Provide a **batch startup** path for the open HRABP-style pond: **variable volume** from **rain minus evaporation** (Fig. 1 / `ForcingSample`) and the lumped concentration correction $-(C_i/V)dV/dt$ with **no CSTR inflow** yet (phase1-04c). Scope is **SI layout only (17 states)**; **proton closure / 18th component** is deferred.
+
+### Technical Implementation
+- **`src/bioprocess_twin/simulator/startup_batch.py`:** `StartupBatchProblem` / `StartupBatchResult`, `evaluate_startup_batch_rhs`, `run_startup_batch` (`solve_ivp` LSODA, hours as time; ALBA rates converted **g m⁻³ d⁻¹ → g m⁻³ h⁻¹** via `/24`); nonnegative **clip** on `y` before `evaluate_liquid_ode_rhs` to satisfy `StateVector` bounds under numerical integration; optional `evaporation_floor_m3_h`; terminal event if `V` hits `volume_minimum_m3`.
+- **`default_reasonable_startup_y0`:** nominal rich-substrate + inoculum vector (not Casagli-calibrated).
+- **`tests/unit/test_startup_batch.py`:** parity when dV/dt=0, concentration-term scaling, volume decrease under evaporation, rain mm→m³ helper.
+
+### Next Steps
+- **phase1-04c:** add continuous-flow dilution; optionally unify time-base conventions with a shared integrator module (phase1-04d).
 
 ---
 

--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -4,6 +4,7 @@ This document is a log of the development process of the project. It is used to 
 
 ## Index
 
+- [2026-05-05 - Sprint phase1-04c (A–C): CSTR transport, Stage 6 RHS, schedule-linked dilution](#devlog-20260505-p104c-abc)
 - [2026-05-02 - Sprint phase1-04c: Startup batch integration (SI 17 + evaporation / volume ODE)](#devlog-20260502-p104c-startup-batch)
 - [2026-04-30 - Sprint phase1-04b: ODE RHS wrapper (`evaluate_liquid_ode_rhs`, no transport)](#devlog-20260430-p104b-ode-rhs)
 - [2026-04-25 - Sprint phase1-04a prep: Fig. 1 daily forcing (T, PAR, evaporation)](#devlog-20260425-fig1-daily-forcing)
@@ -25,6 +26,36 @@ This document is a log of the development process of the project. It is used to 
 - [2026-03-12 - Phase 1: Technical Specification & Architecture Definition](#devlog-20260312-phase1-spec-arch)
 - [2026-03-12 - Phase 1: ALBA Model Analysis & Data Digitization](#devlog-20260312-phase1-alba-digitization)
 - [2026-03-10 - Phase 0: Project Initialization and Foundation](#devlog-20260310-phase0-init)
+
+---
+
+<a id="devlog-20260505-p104c-abc"></a>
+
+## [2026-05-05] - Sprint phase1-04c (A–C): CSTR transport, Stage 6 RHS, schedule-linked dilution
+
+### Context & Goals
+
+Deliver the lumped **CSTR dilution** term for the **17-component SI** liquid state so it is **additive** to the Stage 6 kinetic RHS in **g m⁻³ d⁻¹**, split across **`phase1-04c-A`** (pure math), **`phase1-04c-B`** (ODE wiring), and **`phase1-04c-C`** (time-varying volumetric flow and optional influent composition on the **same daily clock** as `DielForcingSchedule` / `ForcingSample`). Deliberately **out of scope**: a single HRAP driver that couples **`startup_batch`** open-volume balance with continuous-flow dilution.
+
+### Technical Implementation
+
+- **`phase1-04c-A`:** Added `src/bioprocess_twin/simulator/cstr_transport.py` — NumPy-only helpers: dilution $(Q/V)(\mathbf{y}_\mathrm{in}-\mathbf{y})$, HRT $\tau=V/Q$, and **m³ h⁻¹ → m³ d⁻¹** via $\times 24$ (aligned with hour/day scaling elsewhere). Module narrative ties to `docs/theory/cstr_mass_balance_and_hrap_lumped_model.md`. Added `tests/unit/test_cstr_transport.py` with **no** import of `evaluate_liquid_rhs`.
+- **`phase1-04c-B`:** Introduced `CstrContinuousConfig` (single bundle for $V$, **m³ d⁻¹** $Q$, and SI $\mathbf{y}_\mathrm{in}$ / `StateVector`) and optional `LiquidOdeRhsProblem.cstr` defaulting to **`None`** so behaviour matches **`phase1-04b`** when unset. `evaluate_liquid_ode_rhs` adds `cstr_dilution_rate_g_m3_d` after `evaluate_liquid_rhs`; `make_liquid_rhs` inherits this path unchanged.
+- **`phase1-04c-C`:** Added `CstrScheduleFlowConfig` and alias `CstrTransportConfig = CstrContinuousConfig | CstrScheduleFlowConfig`. Flow rate follows **`ForcingSample.inflow_m3_h`** from the **same** `schedule.at(t_hours)` already used for kinetics (**one sample per RHS evaluation** for **T**, **PAR**, and **Q**). If `inflow_m3_h` is **`None`**, transport uses $Q=0$ (same semantics as constant config with zero flow). Optional **callable** influent $f(t_\mathrm{wrapped})$ with $t_\mathrm{wrapped}\in[0,24)$ for explicit **daily periodicity** under multi-day integration in absolute hours; CSV ingestion deferred.
+- **Design choices:** Use **m³ d⁻¹** for $Q$ and **m³** for $V$ so $Q/V$ is **d⁻¹**, matching `dcdt_g_m3_d` without mixed units. Variable $Q(t)$ reuses `DielForcingSchedule` optional drivers (constant or callable) instead of duplicating parallel series.
+- **Files touched:** 
+  - `src/bioprocess_twin/simulator/liquid_ode_rhs.py` (`CstrContinuousConfig`, `CstrScheduleFlowConfig`, `q_m3_per_d_from_forcing_sample`, `effective_y_in_schedule`, branching in `evaluate_liquid_ode_rhs`); 
+  - `src/bioprocess_twin/simulator/__init__.py` (public exports); 
+  - `tests/unit/test_liquid_ode_rhs.py` and `tests/unit/test_cstr_transport.py` for parity vs constant $Q$, $Q=0$, schedule vs continuous flow, callable influent decomposition, HRT checks.
+
+### 💡 Deep Dive: One forcing sample, two budgets
+
+Kinetics and dilution both consume **`DielForcingSchedule.at(t_hours)`**. Reusing that **`ForcingSample`** for `inflow_m3_h` guarantees **T**, **irradiance**, and **Q** stay **consistent at the same wrapped clock time**—important when `inflow_m3_h` is a callable of hour-of-day. The dilution term remains **$(Q/V)(\mathbf{y}_\mathrm{in}-\mathbf{y})$** in **g m⁻³ d⁻¹** per component conventions; only the **scalar** $Q$ (and optionally $\mathbf{y}_\mathrm{in}$) varies with the schedule.
+
+### Next Steps
+
+- **`phase1-04d`:** stiff-friendly time integrator driver and documented tolerances.
+- Optional later: unify **open-volume** `startup_batch` with **continuous-flow** dilution in one simulation product path if required.
 
 ---
 

--- a/src/bioprocess_twin/simulator/__init__.py
+++ b/src/bioprocess_twin/simulator/__init__.py
@@ -1,6 +1,13 @@
 """Simulation orchestration utilities."""
 
+from bioprocess_twin.simulator.cstr_transport import (
+    cstr_dilution_rate_g_m3_d,
+    hrt_days,
+    q_m3_per_day_from_hrt_days,
+    q_m3_per_day_from_m3_per_hour,
+)
 from bioprocess_twin.simulator.liquid_ode_rhs import (
+    CstrContinuousConfig,
     LiquidOdeRhsProblem,
     evaluate_liquid_ode_rhs,
     make_liquid_rhs,
@@ -27,12 +34,17 @@ from bioprocess_twin.simulator.startup_batch import (
 __all__ = [
     "AlbaLiquidRhsResult",
     "BiomassConcentrations",
+    "CstrContinuousConfig",
     "EnvironmentalSnapshot",
     "LiquidOdeRhsProblem",
     "LiquidRhsDiagnostics",
+    "cstr_dilution_rate_g_m3_d",
     "evaluate_liquid_ode_rhs",
     "evaluate_liquid_rhs",
+    "hrt_days",
     "make_liquid_rhs",
+    "q_m3_per_day_from_hrt_days",
+    "q_m3_per_day_from_m3_per_hour",
     "state_vector_from_y",
     "StartupBatchProblem",
     "StartupBatchResult",

--- a/src/bioprocess_twin/simulator/__init__.py
+++ b/src/bioprocess_twin/simulator/__init__.py
@@ -8,9 +8,13 @@ from bioprocess_twin.simulator.cstr_transport import (
 )
 from bioprocess_twin.simulator.liquid_ode_rhs import (
     CstrContinuousConfig,
+    CstrScheduleFlowConfig,
+    CstrTransportConfig,
     LiquidOdeRhsProblem,
+    effective_y_in_schedule,
     evaluate_liquid_ode_rhs,
     make_liquid_rhs,
+    q_m3_per_d_from_forcing_sample,
 )
 from bioprocess_twin.simulator.liquid_rhs import (
     AlbaLiquidRhsResult,
@@ -35,14 +39,18 @@ __all__ = [
     "AlbaLiquidRhsResult",
     "BiomassConcentrations",
     "CstrContinuousConfig",
+    "CstrScheduleFlowConfig",
+    "CstrTransportConfig",
     "EnvironmentalSnapshot",
     "LiquidOdeRhsProblem",
     "LiquidRhsDiagnostics",
     "cstr_dilution_rate_g_m3_d",
+    "effective_y_in_schedule",
     "evaluate_liquid_ode_rhs",
     "evaluate_liquid_rhs",
     "hrt_days",
     "make_liquid_rhs",
+    "q_m3_per_d_from_forcing_sample",
     "q_m3_per_day_from_hrt_days",
     "q_m3_per_day_from_m3_per_hour",
     "state_vector_from_y",

--- a/src/bioprocess_twin/simulator/__init__.py
+++ b/src/bioprocess_twin/simulator/__init__.py
@@ -13,6 +13,16 @@ from bioprocess_twin.simulator.liquid_rhs import (
     evaluate_liquid_rhs,
     state_vector_from_y,
 )
+from bioprocess_twin.simulator.startup_batch import (
+    StartupBatchProblem,
+    StartupBatchResult,
+    default_reasonable_startup_y0,
+    evaluate_startup_batch_rhs,
+    evaporation_rate_m3_h,
+    rain_inflow_m3_h,
+    run_startup_batch,
+    volume_derivative_m3_h,
+)
 
 __all__ = [
     "AlbaLiquidRhsResult",
@@ -24,4 +34,12 @@ __all__ = [
     "evaluate_liquid_rhs",
     "make_liquid_rhs",
     "state_vector_from_y",
+    "StartupBatchProblem",
+    "StartupBatchResult",
+    "default_reasonable_startup_y0",
+    "evaluate_startup_batch_rhs",
+    "evaporation_rate_m3_h",
+    "rain_inflow_m3_h",
+    "run_startup_batch",
+    "volume_derivative_m3_h",
 ]

--- a/src/bioprocess_twin/simulator/cstr_transport.py
+++ b/src/bioprocess_twin/simulator/cstr_transport.py
@@ -1,0 +1,85 @@
+"""
+Pure CSTR dilution transport for the lumped liquid state (phase1-04c-A).
+
+Vector transport term for a single perfectly mixed compartment with constant volume,
+equal inflow and outflow rate:
+
+    dC/dt_transport = (Q/V)(C_in - C)
+
+See docs/theory/cstr_mass_balance_and_hrap_lumped_model.md (eq. 4.1 in-repo narrative).
+
+Units are aligned with Stage 6 RHS output dcdt_g_m3_d: take Q in m³ d⁻¹
+and V in m³ so Q/V is d⁻¹, making the transport contribution per day
+(g m⁻³ d⁻¹ per component, consistent with each state's convention).
+
+This module does not call evaluate_liquid_rhs yet.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from bioprocess_twin.models.stoichiometry import N_STATE
+
+
+def q_m3_per_day_from_m3_per_hour(q_m3_per_h: float) -> float:
+    """
+    Convert volumetric flow from m³ h⁻¹ (e.g. ForcingSample.inflow_m3_h) to m³ d⁻¹.
+
+    Uses 24 h per day (same convention as startup_batch time scaling).
+    """
+    if q_m3_per_h < 0:
+        raise ValueError("q_m3_per_h must be non-negative")
+    return float(q_m3_per_h) * 24.0
+
+
+def hrt_days(volume_m3: float, q_m3_per_d: float) -> float:
+    """Hydraulic retention time τ = V/Q [d], for q_m3_per_d > 0."""
+    if volume_m3 <= 0:
+        raise ValueError("volume_m3 must be positive")
+    if q_m3_per_d <= 0:
+        raise ValueError("q_m3_per_d must be positive for finite HRT")
+    return float(volume_m3) / float(q_m3_per_d)
+
+
+def q_m3_per_day_from_hrt_days(volume_m3: float, hrt_days: float) -> float:
+    """Inflow rate Q = V/τ [m³ d⁻¹] from volume and HRT [d]."""
+    if volume_m3 <= 0:
+        raise ValueError("volume_m3 must be positive")
+    if hrt_days <= 0:
+        raise ValueError("hrt_days must be positive")
+    return float(volume_m3) / float(hrt_days)
+
+
+def cstr_dilution_rate_g_m3_d(
+    y: np.ndarray,
+    y_in: np.ndarray,
+    *,
+    volume_m3: float,
+    q_m3_per_d: float,
+) -> np.ndarray:
+    """
+    Transport-only contribution (Q/V)(y_in - y), per day, shape (N_STATE,).
+
+    Parameters
+    ----------
+    y, y_in
+        SI liquid state vectors (length N_STATE), same units as StateVector
+        components (gCOD m⁻³, gN m⁻³, … per field).
+    volume_m3
+        Reactor liquid volume [m³].
+    q_m3_per_d
+        Volumetric inflow rate [m³ d⁻¹] (equal outflow, constant V).
+    """
+    ya = np.asarray(y, dtype=np.float64).ravel()
+    yina = np.asarray(y_in, dtype=np.float64).ravel()
+    if ya.size != N_STATE:
+        raise ValueError(f"y must have length {N_STATE}, got {ya.size}")
+    if yina.size != N_STATE:
+        raise ValueError(f"y_in must have length {N_STATE}, got {yina.size}")
+    if volume_m3 <= 0:
+        raise ValueError("volume_m3 must be positive")
+    if q_m3_per_d < 0:
+        raise ValueError("q_m3_per_d must be non-negative")
+    k = float(q_m3_per_d) / float(volume_m3)
+    return k * (yina - ya)

--- a/src/bioprocess_twin/simulator/liquid_ode_rhs.py
+++ b/src/bioprocess_twin/simulator/liquid_ode_rhs.py
@@ -1,4 +1,4 @@
-"""ODE-sized liquid RHS: Stage 6 only, with diel forcing (phase1-04a) and no transport (04c)."""
+"""ODE-sized liquid RHS: Stage 6 with diel forcing (phase1-04a) and optional CSTR dilution (phase1-04c-B)."""
 
 from __future__ import annotations
 
@@ -7,12 +7,55 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from bioprocess_twin.core.state import StateVector, StateVectorVariant
 from bioprocess_twin.forcing.diel_forcing_schedule import DielForcingSchedule, to_env_conditions
 from bioprocess_twin.models.chemistry import AlbaDissociationConstantsRef, AlbaDissociationEnthalpy, PHSolverOptions
 from bioprocess_twin.models.gas_transfer import GasTransferConditions
 from bioprocess_twin.models.kinetic_parameters import KineticParameters
+from bioprocess_twin.models.stoichiometry import N_STATE
 
+from .cstr_transport import cstr_dilution_rate_g_m3_d
 from .liquid_rhs import evaluate_liquid_rhs, state_vector_from_y
+
+
+@dataclass(frozen=True, slots=True)
+class CstrContinuousConfig:
+    """
+    Constant-parameter CSTR dilution for continuous-flow simulation.
+
+    q_m3_per_d is volumetric inflow [m³ d⁻¹] (same outflow, constant volume);
+    y_in is the SI influent state vector, same layout as StateVector / y.
+
+    Time-varying Q(t) or y_in(t) is not handled here (phase1-04c-C).
+    """
+
+    volume_m3: float
+    q_m3_per_d: float
+    y_in: np.ndarray
+
+    def __post_init__(self) -> None:
+        if self.volume_m3 <= 0:
+            raise ValueError("cstr volume_m3 must be positive")
+        if self.q_m3_per_d < 0:
+            raise ValueError("cstr q_m3_per_d must be non-negative")
+        arr = np.asarray(self.y_in, dtype=np.float64).ravel()
+        if arr.size != N_STATE:
+            raise ValueError(f"cstr y_in must have length {N_STATE}, got {arr.size}")
+        object.__setattr__(self, "y_in", arr.copy())
+
+    @classmethod
+    def from_influent(
+        cls,
+        volume_m3: float,
+        q_m3_per_d: float,
+        y_in: StateVector | np.ndarray,
+    ) -> CstrContinuousConfig:
+        """Build from a StateVector or a length N_STATE array."""
+        if isinstance(y_in, StateVector):
+            arr = y_in.to_array(variant=StateVectorVariant.SI)
+        else:
+            arr = np.asarray(y_in, dtype=np.float64).ravel()
+        return cls(volume_m3=volume_m3, q_m3_per_d=q_m3_per_d, y_in=arr)
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,6 +65,8 @@ class LiquidOdeRhsProblem:
 
     Time: t_hours passed to the RHS is hours of day (clock time). Values outside
     [0,24) are reduced modulo 24 inside DielForcingSchedule.at (same convention as forcing).
+
+    Optional cstr adds (Q/V)(y_in - y) per day, aligned with dcdt_g_m3_d.
     """
 
     schedule: DielForcingSchedule
@@ -34,6 +79,7 @@ class LiquidOdeRhsProblem:
     options: PHSolverOptions | None = None
     k_ref: AlbaDissociationConstantsRef | None = None
     dh: AlbaDissociationEnthalpy | None = None
+    cstr: CstrContinuousConfig | None = None
 
 
 def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOdeRhsProblem) -> np.ndarray:
@@ -44,6 +90,9 @@ def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOde
     to_env_conditions(..., ph=problem.placeholder_ph_for_env). Solved pH inside
     evaluate_liquid_rhs still comes from SI.6 charge balance (initial_ph is only the
     solver guess).
+
+    If problem.cstr is set, adds the constant-parameter CSTR dilution term
+    (Q/V)(y_in - y) from cstr_dilution_rate_g_m3_d (same units).
     """
     st = state_vector_from_y(y)
     sample = problem.schedule.at(t_hours)
@@ -60,7 +109,17 @@ def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOde
         k_ref=problem.k_ref,
         dh=problem.dh,
     )
-    return np.asarray(out.dcdt_g_m3_d, dtype=np.float64).ravel()
+    dcdt = np.asarray(out.dcdt_g_m3_d, dtype=np.float64).ravel()
+    if problem.cstr is not None:
+        cfg = problem.cstr
+        transport = cstr_dilution_rate_g_m3_d(
+            y,
+            cfg.y_in,
+            volume_m3=cfg.volume_m3,
+            q_m3_per_d=cfg.q_m3_per_d,
+        )
+        dcdt = dcdt + transport
+    return dcdt
 
 
 def make_liquid_rhs(problem: LiquidOdeRhsProblem) -> Callable[[float, np.ndarray], np.ndarray]:

--- a/src/bioprocess_twin/simulator/liquid_ode_rhs.py
+++ b/src/bioprocess_twin/simulator/liquid_ode_rhs.py
@@ -1,21 +1,59 @@
-"""ODE-sized liquid RHS: Stage 6 with diel forcing (phase1-04a) and optional CSTR dilution (phase1-04c-B)."""
+"""ODE-sized liquid RHS: Stage 6 with diel forcing (phase1-04a) and optional CSTR dilution (04c-B, 04c-C)."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 
 from bioprocess_twin.core.state import StateVector, StateVectorVariant
-from bioprocess_twin.forcing.diel_forcing_schedule import DielForcingSchedule, to_env_conditions
+from bioprocess_twin.forcing.diel_forcing_schedule import (
+    DielForcingSchedule,
+    ForcingSample,
+    to_env_conditions,
+)
 from bioprocess_twin.models.chemistry import AlbaDissociationConstantsRef, AlbaDissociationEnthalpy, PHSolverOptions
 from bioprocess_twin.models.gas_transfer import GasTransferConditions
 from bioprocess_twin.models.kinetic_parameters import KineticParameters
 from bioprocess_twin.models.stoichiometry import N_STATE
 
-from .cstr_transport import cstr_dilution_rate_g_m3_d
+from .cstr_transport import cstr_dilution_rate_g_m3_d, q_m3_per_day_from_m3_per_hour
 from .liquid_rhs import evaluate_liquid_rhs, state_vector_from_y
+
+_CSTR_CLOCK_WRAP = 24.0
+
+
+def _wrap_clock_hours(t_hours: float) -> float:
+    """Same wrapping convention as DielForcingSchedule.at (daily repeating clock)."""
+    return float(np.mod(t_hours, _CSTR_CLOCK_WRAP))
+
+
+def q_m3_per_d_from_forcing_sample(sample: ForcingSample) -> float:
+    """
+    Volumetric inflow [m³ d⁻¹] from ``ForcingSample.inflow_m3_h``.
+
+    If ``inflow_m3_h`` is missing, returns 0 (no dilution), matching constant CSTR with Q=0.
+    """
+    q_h = sample.inflow_m3_h
+    if q_h is None:
+        return 0.0
+    return q_m3_per_day_from_m3_per_hour(float(q_h))
+
+
+def _normalize_y_in_vector(raw: StateVector | np.ndarray) -> np.ndarray:
+    """Normalize the influent state vector to the SI layout."""
+    if isinstance(raw, StateVector):
+        arr = raw.to_array(variant=StateVectorVariant.SI)
+    else:
+        arr = np.asarray(raw, dtype=np.float64).ravel()
+    if arr.size != N_STATE:
+        raise ValueError(f"cstr y_in must have length {N_STATE}, got {arr.size}")
+    return arr
+
+
+YInSchedule: TypeAlias = np.ndarray | StateVector | Callable[[float], np.ndarray | StateVector]
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,7 +64,7 @@ class CstrContinuousConfig:
     q_m3_per_d is volumetric inflow [m³ d⁻¹] (same outflow, constant volume);
     y_in is the SI influent state vector, same layout as StateVector / y.
 
-    Time-varying Q(t) or y_in(t) is not handled here (phase1-04c-C).
+    For flow taken from ``DielForcingSchedule.inflow_m3_h``, use ``CstrScheduleFlowConfig``.
     """
 
     volume_m3: float
@@ -59,6 +97,43 @@ class CstrContinuousConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class CstrScheduleFlowConfig:
+    """
+    CSTR dilution with volumetric inflow from problem.schedule.at(t).inflow_m3_h.
+
+    inflow_m3_h [m³ h⁻¹] is converted to [m³ d⁻¹] via × 24 (same as cstr_transport).
+    If the sample has inflow_m3_h is None, dilution is zero for that instant.
+
+    y_in may be a constant SI vector or callable(t_wrapped) where t_wrapped is
+    in [0, 24) (daily repeating clock; same wrapping as DielForcingSchedule.at).
+    """
+
+    volume_m3: float
+    y_in: YInSchedule
+
+    def __post_init__(self) -> None:
+        if self.volume_m3 <= 0:
+            raise ValueError("cstr volume_m3 must be positive")
+        if callable(self.y_in):
+            return
+        arr = _normalize_y_in_vector(self.y_in)
+        object.__setattr__(self, "y_in", arr)
+
+
+def effective_y_in_schedule(cfg: CstrScheduleFlowConfig, t_hours: float) -> np.ndarray:
+    """Resolve y_in at clock time t_hours (wrapped to [0, 24) for callables)."""
+    tw = _wrap_clock_hours(t_hours)
+    spec = cfg.y_in
+    if callable(spec):
+        return _normalize_y_in_vector(spec(tw)).copy()
+    assert isinstance(spec, np.ndarray)
+    return np.asarray(spec, dtype=np.float64).ravel().copy()
+
+
+CstrTransportConfig: TypeAlias = CstrContinuousConfig | CstrScheduleFlowConfig
+
+
+@dataclass(frozen=True, slots=True)
 class LiquidOdeRhsProblem:
     """
     Immutable bundle for evaluate_liquid_ode_rhs.
@@ -67,6 +142,8 @@ class LiquidOdeRhsProblem:
     [0,24) are reduced modulo 24 inside DielForcingSchedule.at (same convention as forcing).
 
     Optional cstr adds (Q/V)(y_in - y) per day, aligned with dcdt_g_m3_d.
+    Use CstrContinuousConfig for constant Q, or CstrScheduleFlowConfig so Q
+    follows schedule inflow_m3_h (phase1-04c-C).
     """
 
     schedule: DielForcingSchedule
@@ -79,7 +156,7 @@ class LiquidOdeRhsProblem:
     options: PHSolverOptions | None = None
     k_ref: AlbaDissociationConstantsRef | None = None
     dh: AlbaDissociationEnthalpy | None = None
-    cstr: CstrContinuousConfig | None = None
+    cstr: CstrTransportConfig | None = None
 
 
 def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOdeRhsProblem) -> np.ndarray:
@@ -91,8 +168,10 @@ def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOde
     evaluate_liquid_rhs still comes from SI.6 charge balance (initial_ph is only the
     solver guess).
 
-    If problem.cstr is set, adds the constant-parameter CSTR dilution term
-    (Q/V)(y_in - y) from cstr_dilution_rate_g_m3_d (same units).
+    If problem.cstr is a CstrContinuousConfig, adds constant-Q dilution.
+
+    If it is a CstrScheduleFlowConfig, Q comes from problem.schedule.at(t_hours)
+    (inflow_m3_h → m³ d⁻¹); y_in may vary with wrapped clock time for callables.
     """
     st = state_vector_from_y(y)
     sample = problem.schedule.at(t_hours)
@@ -110,16 +189,28 @@ def evaluate_liquid_ode_rhs(t_hours: float, y: np.ndarray, *, problem: LiquidOde
         dh=problem.dh,
     )
     dcdt = np.asarray(out.dcdt_g_m3_d, dtype=np.float64).ravel()
-    if problem.cstr is not None:
-        cfg = problem.cstr
+    cfg = problem.cstr
+    if cfg is None:
+        return dcdt
+    if isinstance(cfg, CstrContinuousConfig):
         transport = cstr_dilution_rate_g_m3_d(
             y,
             cfg.y_in,
             volume_m3=cfg.volume_m3,
             q_m3_per_d=cfg.q_m3_per_d,
         )
-        dcdt = dcdt + transport
-    return dcdt
+        return dcdt + transport
+    if isinstance(cfg, CstrScheduleFlowConfig):
+        q_d = q_m3_per_d_from_forcing_sample(sample)
+        y_eff = effective_y_in_schedule(cfg, t_hours)
+        transport = cstr_dilution_rate_g_m3_d(
+            y,
+            y_eff,
+            volume_m3=cfg.volume_m3,
+            q_m3_per_d=q_d,
+        )
+        return dcdt + transport
+    raise TypeError(f"unsupported cstr config type: {type(cfg)!r}")
 
 
 def make_liquid_rhs(problem: LiquidOdeRhsProblem) -> Callable[[float, np.ndarray], np.ndarray]:

--- a/src/bioprocess_twin/simulator/startup_batch.py
+++ b/src/bioprocess_twin/simulator/startup_batch.py
@@ -1,0 +1,285 @@
+"""
+Batch startup integration (SI 17-state ALBA) with open-pond water balance.
+
+Couples evaluate_liquid_ode_rhs (rates in g m⁻³ d⁻¹) to volume change from
+evaporation and optional rain on surface_area_m2. Independent variable is
+hours; biological rates are converted to per-hour (/24).
+
+Volume ODE::
+
+    dV/dt = Q_rain(t) - E(t)
+
+Concentration correction for pure-water loss/gain (well-mixed lump, see
+docs/theory/cstr_mass_balance_and_hrap_lumped_model.md §3.1)::
+
+    dC_i/dt = r_i - (C_i/V) dV/dt
+
+with r_i from ALBA in g m⁻³ d⁻¹, converted to g m⁻³ h⁻¹.
+
+Only 17-component SI layout; proton closure / 18th state is out of scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from bioprocess_twin.core.state import StateVector, StateVectorVariant
+from bioprocess_twin.forcing.diel_forcing_schedule import ForcingSample
+from bioprocess_twin.models.stoichiometry import N_STATE
+
+from .liquid_ode_rhs import LiquidOdeRhsProblem, evaluate_liquid_ode_rhs
+
+# Augmented state: 17 ALBA components + volume [m³]
+_STARTUP_N = N_STATE + 1
+_VOLUME_INDEX = N_STATE
+
+# Biological RHS from evaluate_liquid_ode_rhs is per day; integration uses hours.
+_HOURS_PER_DAY = 24.0
+
+
+def _as_length17_ndarray(y0: StateVector | np.ndarray) -> np.ndarray:
+    """
+    Convert StateVector to numpy array of length 17.
+    """
+    if isinstance(y0, StateVector):
+        arr = y0.to_array(variant=StateVectorVariant.SI)
+    else:
+        arr = np.asarray(y0, dtype=np.float64).ravel()
+    if arr.size != N_STATE:
+        raise ValueError(f"startup y0 must have length {N_STATE} (SI layout), got {arr.size}")
+    return arr
+
+
+def rain_inflow_m3_h(sample: ForcingSample, surface_area_m2: float, *, include_rain: bool) -> float:
+    """
+    Convert mm h⁻¹ rain depth over surface_area_m2 to m³ h⁻¹ inflow on the pond surface.
+
+    If include_rain is False or rain_mm_h is missing, returns 0.
+    """
+    if not include_rain:
+        return 0.0
+    if sample.rain_mm_h is None:
+        return 0.0
+    return float(sample.rain_mm_h) * float(surface_area_m2) / 1000.0
+
+
+def evaporation_rate_m3_h(sample: ForcingSample, evaporation_floor_m3_h: float) -> float:
+    """Pond-scale evaporation rate [m³ h⁻¹] with optional numerical floor."""
+    return max(float(sample.evaporation_m3_h), float(evaporation_floor_m3_h))
+
+
+def volume_derivative_m3_h(
+    sample: ForcingSample,
+    surface_area_m2: float,
+    *,
+    include_rain: bool,
+    evaporation_floor_m3_h: float,
+) -> float:
+    """Net volumetric rate dV/dt [m³ h⁻¹] (rain minus evaporation)."""
+    q_rain = rain_inflow_m3_h(sample, surface_area_m2, include_rain=include_rain)
+    e = evaporation_rate_m3_h(sample, evaporation_floor_m3_h)
+    return q_rain - e
+
+
+@dataclass(frozen=True, slots=True)
+class StartupBatchProblem:
+    """
+    Configuration for run_startup_batch.
+
+    Time span is [0, startup_days * 24) hours; DielForcingSchedule.at(t)
+    wraps clock time modulo 24 h so diurnal forcing repeats each simulated day.
+    """
+
+    problem: LiquidOdeRhsProblem
+    startup_days: float
+    y0: StateVector | np.ndarray
+    volume_m3_initial: float
+    surface_area_m2: float
+    include_rain: bool = True
+    evaporation_floor_m3_h: float = 0.0
+    """Lower bound on evaporation [m³ h⁻¹] when the schedule would otherwise give zero."""
+
+    volume_minimum_m3: float = 0.01
+    """Integration stops (terminal event) if V reaches this level."""
+
+    def __post_init__(self) -> None:
+        if self.startup_days <= 0:
+            raise ValueError("startup_days must be positive")
+        if self.volume_m3_initial <= 0:
+            raise ValueError("volume_m3_initial must be positive")
+        if self.surface_area_m2 <= 0:
+            raise ValueError("surface_area_m2 must be positive")
+        if self.evaporation_floor_m3_h < 0:
+            raise ValueError("evaporation_floor_m3_h must be non-negative")
+        if self.volume_minimum_m3 <= 0:
+            raise ValueError("volume_minimum_m3 must be positive")
+        _ = _as_length17_ndarray(self.y0)
+
+
+@dataclass(frozen=True, slots=True)
+class StartupBatchResult:
+    t_hours: np.ndarray
+    """Sample times [h], shape (n,)."""
+
+    y: np.ndarray
+    """State trajectory, shape (n, 17) (SI)."""
+
+    volume_m3: np.ndarray
+    """Volume trajectory [m³], shape (n,)."""
+
+    success: bool
+    message: str
+
+
+def evaluate_startup_batch_rhs(
+    t_hours: float,
+    z: np.ndarray,
+    *,
+    problem_cfg: StartupBatchProblem,
+) -> np.ndarray:
+    """
+    Augmented RHS for startup: return dz/dt with z = concat(y, [V]).
+
+    t_hours may exceed 24; forcing uses the schedule's modulo-24 convention.
+
+    Units: dz[:17]/dt in g m⁻³ h⁻¹; dz[17]/dt in m³ h⁻¹.
+    """
+    z = np.asarray(z, dtype=np.float64).ravel()
+    if z.size != _STARTUP_N:
+        raise ValueError(f"augmented state must have length {_STARTUP_N}, got {z.size}")
+
+    y_raw = z[:N_STATE]
+    # Integrators can produce slightly negative values at a step; StateVector and
+    # Monod terms require nonnegative inventories. Clip before calling Stage-6 RHS.
+    y = np.maximum(np.asarray(y_raw, dtype=np.float64), 0.0)
+
+    v = float(z[_VOLUME_INDEX])
+    v_safe = max(v, float(problem_cfg.volume_minimum_m3))
+
+    sample = problem_cfg.problem.schedule.at(t_hours)
+    dVdt = volume_derivative_m3_h(
+        sample,
+        problem_cfg.surface_area_m2,
+        include_rain=problem_cfg.include_rain,
+        evaporation_floor_m3_h=problem_cfg.evaporation_floor_m3_h,
+    )
+
+    dydt_day = evaluate_liquid_ode_rhs(t_hours, y, problem=problem_cfg.problem)
+    dydt_hour = np.asarray(dydt_day, dtype=np.float64) / _HOURS_PER_DAY
+
+    # Concentration change due to volume change (same formula for all 17 SI components;
+    # see SIMULATOR_MATH / lumped control volume with variable volume).
+    conc_term = -(y / v_safe) * dVdt
+    dydt = dydt_hour + conc_term
+
+    return np.concatenate([dydt, np.array([dVdt], dtype=np.float64)])
+
+
+def _event_volume_minimum(_t: float, z: np.ndarray, *, V_minimum: float) -> float:
+    """
+    Event function for volume minimum: return V - V_minimum.
+    Allows the integrator to stop if V reaches V_minimum.
+    """
+    return float(z[_VOLUME_INDEX]) - float(V_minimum)
+
+
+def default_reasonable_startup_y0() -> np.ndarray:
+    """
+    A documented nominal SI initial condition: elevated substrate and modest inoculum.
+
+    Values are order-of-magnitude placeholders for development tests, not calibrated
+    to Casagli et al. (2021).
+    """
+    st = StateVector(
+        X_ALG=50.0,
+        X_AOB=12.0,
+        X_NOB=6.0,
+        X_H=70.0,
+        X_S=140.0,
+        X_I=25.0,
+        S_S=220.0,
+        S_I=18.0,
+        S_IC=40.0,
+        S_ND=42.0,
+        S_NH=14.0,
+        S_NO2=0.08,
+        S_NO3=4.0,
+        S_N2=0.15,
+        S_PO4=15.0,
+        S_O2=6.0,
+        S_H2O=0.0,
+    )
+    return st.to_array(variant=StateVectorVariant.SI)
+
+
+def run_startup_batch(
+    cfg: StartupBatchProblem,
+    *,
+    method: str = "LSODA",
+    rtol: float = 1e-6,
+    atol: float = 1e-9,
+    max_step: float | None = 6.0,
+    t_eval_hours: np.ndarray | None = None,
+) -> StartupBatchResult:
+    """
+    Integrate startup batch (SI + volume) from t=0 to t = startup_days * 24 h.
+
+    If t_eval_hours is None, samples every hour on [0, startup_days * 24].
+    """
+    y0 = _as_length17_ndarray(cfg.y0)
+    t_end = float(cfg.startup_days) * _HOURS_PER_DAY
+    z0 = np.concatenate([y0, np.array([float(cfg.volume_m3_initial)], dtype=np.float64)])
+
+    def rhs(t: float, z: np.ndarray) -> np.ndarray:
+        return evaluate_startup_batch_rhs(t, z, problem_cfg=cfg)
+
+    vmin = float(cfg.volume_minimum_m3)
+
+    def event_volume(t: float, z: np.ndarray) -> float:
+        return _event_volume_minimum(t, z, V_minimum=vmin)
+
+    event_volume.terminal = True  # type: ignore[attr-defined]
+    event_volume.direction = -1.0  # type: ignore[attr-defined]
+
+    if t_eval_hours is None:
+        n_steps = int(np.ceil(t_end)) + 1
+        t_eval = np.linspace(0.0, t_end, max(n_steps, 2))
+    else:
+        t_eval = np.asarray(t_eval_hours, dtype=np.float64)
+
+    sol = solve_ivp(
+        rhs,
+        (0.0, t_end),
+        z0,
+        method=method,
+        t_eval=t_eval,
+        rtol=rtol,
+        atol=atol,
+        max_step=max_step,
+        events=event_volume,
+    )
+
+    if sol.t.size == 0:
+        return StartupBatchResult(
+            t_hours=np.array([0.0]),
+            y=y0.reshape(1, -1),
+            volume_m3=np.array([float(cfg.volume_m3_initial)]),
+            success=False,
+            message="integrator returned empty time grid",
+        )
+
+    y_traj = sol.y[:N_STATE].T
+    v_traj = sol.y[_VOLUME_INDEX]
+    msg = sol.message or ""
+    ok = bool(sol.success)
+
+    return StartupBatchResult(
+        t_hours=np.asarray(sol.t, dtype=np.float64),
+        y=np.asarray(y_traj, dtype=np.float64),
+        volume_m3=np.asarray(v_traj, dtype=np.float64),
+        success=ok,
+        message=msg,
+    )

--- a/tests/unit/test_cstr_transport.py
+++ b/tests/unit/test_cstr_transport.py
@@ -1,0 +1,86 @@
+"""Unit tests for pure CSTR dilution algebra (phase1-04c-A)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bioprocess_twin.models.stoichiometry import N_STATE
+from bioprocess_twin.simulator.cstr_transport import (
+    cstr_dilution_rate_g_m3_d,
+    hrt_days,
+    q_m3_per_day_from_hrt_days,
+    q_m3_per_day_from_m3_per_hour,
+)
+
+
+def test_q_zero_gives_zero_transport() -> None:
+    """Test that when Q = 0, the transport rate is zero."""
+    y = np.arange(N_STATE, dtype=np.float64)
+    y_in = np.arange(N_STATE, dtype=np.float64) + 10.0
+    out = cstr_dilution_rate_g_m3_d(y, y_in, volume_m3=17.0, q_m3_per_d=0.0)
+    assert out.shape == (N_STATE,)
+    np.testing.assert_allclose(out, 0.0, atol=0.0)
+
+
+def test_y_equals_y_in_gives_zero() -> None:
+    """Test that when y = y_in, the transport rate is zero."""
+    y = np.linspace(1.0, 2.0, N_STATE)
+    out = cstr_dilution_rate_g_m3_d(y, y.copy(), volume_m3=10.0, q_m3_per_d=5.0)
+    np.testing.assert_allclose(out, 0.0, atol=0.0)
+
+
+def test_shape_validation() -> None:
+    """Test that the function raises an error if the input arrays are not the correct shape."""
+    y_ok = np.zeros(N_STATE)
+    y_bad = np.zeros(N_STATE - 1)
+    with pytest.raises(ValueError, match="y must have length"):
+        cstr_dilution_rate_g_m3_d(y_bad, y_ok, volume_m3=1.0, q_m3_per_d=1.0)
+    with pytest.raises(ValueError, match="y_in must have length"):
+        cstr_dilution_rate_g_m3_d(y_ok, y_bad, volume_m3=1.0, q_m3_per_d=1.0)
+
+
+def test_volume_and_q_validation() -> None:
+    y = np.zeros(N_STATE)
+    with pytest.raises(ValueError, match="volume_m3"):
+        cstr_dilution_rate_g_m3_d(y, y, volume_m3=0.0, q_m3_per_d=1.0)
+    with pytest.raises(ValueError, match="q_m3_per_d"):
+        cstr_dilution_rate_g_m3_d(y, y, volume_m3=10.0, q_m3_per_d=-1.0)
+
+
+def test_hrt_and_round_trip_casagli_order() -> None:
+    """Test that the function returns the correct HRT and that the round trip conversion is correct."""
+    v = 17.0
+    q = 3.4
+    tau = hrt_days(v, q)
+    assert tau == pytest.approx(5.0)
+    q_back = q_m3_per_day_from_hrt_days(v, tau)
+    assert q_back == pytest.approx(q)
+    assert q_m3_per_day_from_m3_per_hour(q / 24.0) == pytest.approx(q)
+
+
+def test_q_m3_per_hour_conversion() -> None:
+    """Test that the function returns the correct Q in m³ d⁻¹ for a given Q in m³ h⁻¹."""
+    assert q_m3_per_day_from_m3_per_hour(1.0) == pytest.approx(24.0)
+    with pytest.raises(ValueError):
+        q_m3_per_day_from_m3_per_hour(-0.1)
+
+
+def test_tracer_first_component_hand_check() -> None:
+    """Single nonzero concentration in first pool; verify -(Q/V)*c."""
+    y = np.zeros(N_STATE)
+    c = 100.0
+    y[0] = c
+    y_in = np.zeros(N_STATE)
+    v = 17.0
+    q = 3.4
+    out = cstr_dilution_rate_g_m3_d(y, y_in, volume_m3=v, q_m3_per_d=q)
+    expected_first = -(q / v) * c
+    assert out[0] == pytest.approx(expected_first)
+    np.testing.assert_allclose(out[1:], 0.0, atol=0.0)
+
+
+def test_hrt_requires_positive_q() -> None:
+    """Test that the function raises an error if Q is negative."""
+    with pytest.raises(ValueError, match="q_m3_per_d"):
+        hrt_days(17.0, 0.0)

--- a/tests/unit/test_liquid_ode_rhs.py
+++ b/tests/unit/test_liquid_ode_rhs.py
@@ -1,4 +1,4 @@
-"""Tests for ODE-sized liquid RHS wrapper (phase1-04b, phase1-04c-B CSTR)."""
+"""Tests for ODE-sized liquid RHS wrapper (phase1-04b, phase1-04c-B/C CSTR)."""
 
 from __future__ import annotations
 
@@ -10,12 +10,15 @@ from bioprocess_twin.forcing import DielForcingSchedule, to_env_conditions
 from bioprocess_twin.models.stoichiometry import N_STATE
 from bioprocess_twin.simulator import (
     CstrContinuousConfig,
+    CstrScheduleFlowConfig,
     LiquidOdeRhsProblem,
     cstr_dilution_rate_g_m3_d,
+    effective_y_in_schedule,
     evaluate_liquid_ode_rhs,
     evaluate_liquid_rhs,
     hrt_days,
     make_liquid_rhs,
+    q_m3_per_d_from_forcing_sample,
     state_vector_from_y,
 )
 
@@ -144,3 +147,67 @@ def test_cstr_from_influent_matches_si_array() -> None:
     a = CstrContinuousConfig.from_influent(5.0, 1.0, st)
     b = CstrContinuousConfig(5.0, 1.0, arr)
     np.testing.assert_allclose(a.y_in, b.y_in, rtol=1e-12, atol=1e-12)
+
+
+def test_schedule_cstr_matches_continuous_when_inflow_constant() -> None:
+    """Constant inflow_m3_h on schedule equals constant q_m3_per_d (hour to day scaling)."""
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 13.25
+    q_const_m3_d = 3.4
+    q_h = q_const_m3_d / 24.0
+    schedule = DielForcingSchedule(season="spring", inflow_m3_h=q_h)
+    vol = 17.0
+    y_in = np.linspace(0.3, 1.7, N_STATE)
+    cont = LiquidOdeRhsProblem(
+        schedule=schedule,
+        cstr=CstrContinuousConfig(volume_m3=vol, q_m3_per_d=q_const_m3_d, y_in=y_in),
+    )
+    sched_cfg = LiquidOdeRhsProblem(schedule=schedule, cstr=CstrScheduleFlowConfig(volume_m3=vol, y_in=y_in))
+    np.testing.assert_allclose(
+        evaluate_liquid_ode_rhs(t_hours, y, problem=cont),
+        evaluate_liquid_ode_rhs(t_hours, y, problem=sched_cfg),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_schedule_cstr_missing_inflow_matches_no_transport() -> None:
+    """When schedule has no inflow driver, dilution is zero (same as no cstr)."""
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 5.0
+    schedule = DielForcingSchedule(season="summer")
+    assert schedule.at(t_hours).inflow_m3_h is None
+    base = LiquidOdeRhsProblem(schedule=schedule)
+    with_sched = LiquidOdeRhsProblem(
+        schedule=schedule,
+        cstr=CstrScheduleFlowConfig(volume_m3=12.0, y_in=np.ones(N_STATE)),
+    )
+    np.testing.assert_allclose(
+        evaluate_liquid_ode_rhs(t_hours, y, problem=base),
+        evaluate_liquid_ode_rhs(t_hours, y, problem=with_sched),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert q_m3_per_d_from_forcing_sample(schedule.at(t_hours)) == 0.0
+
+
+def test_schedule_cstr_callable_y_in_matches_explicit_dilution() -> None:
+    def y_in_clock(tw: float) -> np.ndarray:
+        return np.linspace(0.2, 3.0, N_STATE) * (1.0 + 0.02 * tw)
+
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 50.0
+    q_const_m3_d = 2.5
+    schedule = DielForcingSchedule(season="winter", inflow_m3_h=q_const_m3_d / 24.0)
+    vol = 20.0
+    cfg = CstrScheduleFlowConfig(volume_m3=vol, y_in=y_in_clock)
+    no_cstr = LiquidOdeRhsProblem(schedule=schedule)
+    with_sched = LiquidOdeRhsProblem(schedule=schedule, cstr=cfg)
+    bio = evaluate_liquid_ode_rhs(t_hours, y, problem=no_cstr)
+    full = evaluate_liquid_ode_rhs(t_hours, y, problem=with_sched)
+    y_eff = effective_y_in_schedule(cfg, t_hours)
+    dilution = cstr_dilution_rate_g_m3_d(y, y_eff, volume_m3=vol, q_m3_per_d=q_const_m3_d)
+    np.testing.assert_allclose(full, bio + dilution, rtol=1e-12, atol=1e-12)

--- a/tests/unit/test_liquid_ode_rhs.py
+++ b/tests/unit/test_liquid_ode_rhs.py
@@ -1,4 +1,4 @@
-"""Tests for ODE-sized liquid RHS wrapper (phase1-04b)."""
+"""Tests for ODE-sized liquid RHS wrapper (phase1-04b, phase1-04c-B CSTR)."""
 
 from __future__ import annotations
 
@@ -9,9 +9,12 @@ from bioprocess_twin.core.state import StateVector
 from bioprocess_twin.forcing import DielForcingSchedule, to_env_conditions
 from bioprocess_twin.models.stoichiometry import N_STATE
 from bioprocess_twin.simulator import (
+    CstrContinuousConfig,
     LiquidOdeRhsProblem,
+    cstr_dilution_rate_g_m3_d,
     evaluate_liquid_ode_rhs,
     evaluate_liquid_rhs,
+    hrt_days,
     make_liquid_rhs,
     state_vector_from_y,
 )
@@ -91,3 +94,53 @@ def test_wrong_state_length_raises() -> None:
     problem = LiquidOdeRhsProblem(schedule=DielForcingSchedule(season="spring"))
     with pytest.raises(ValueError, match="length"):
         evaluate_liquid_ode_rhs(0.0, np.zeros(5), problem=problem)
+
+
+def test_cstr_q_zero_equivalent_to_no_cstr() -> None:
+    """With q_m3_per_d=0, dilution vanishes; RHS matches the default (no cstr) problem."""
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 8.0
+    schedule = DielForcingSchedule(season="summer")
+    base = LiquidOdeRhsProblem(schedule=schedule)
+    y_in = np.ones(N_STATE)
+    cstr_zero = CstrContinuousConfig(volume_m3=10.0, q_m3_per_d=0.0, y_in=y_in)
+    with_q0 = LiquidOdeRhsProblem(schedule=schedule, cstr=cstr_zero)
+    np.testing.assert_allclose(
+        evaluate_liquid_ode_rhs(t_hours, y, problem=base),
+        evaluate_liquid_ode_rhs(t_hours, y, problem=with_q0),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_cstr_rhs_is_bio_plus_dilution_term() -> None:
+    """Test that the CSTR RHS is the sum of the biological RHS and the dilution term."""
+    st = _stage6_state()
+    y = st.to_array()
+    t_hours = 11.0
+    schedule = DielForcingSchedule(season="autumn")
+    vol = 17.0
+    q = 3.4
+    y_in = np.linspace(0.1, 2.0, N_STATE)
+    cfg = CstrContinuousConfig(volume_m3=vol, q_m3_per_d=q, y_in=y_in)
+    no_cstr = LiquidOdeRhsProblem(schedule=schedule)
+    with_cstr = LiquidOdeRhsProblem(schedule=schedule, cstr=cfg)
+    bio = evaluate_liquid_ode_rhs(t_hours, y, problem=no_cstr)
+    full = evaluate_liquid_ode_rhs(t_hours, y, problem=with_cstr)
+    dilution = cstr_dilution_rate_g_m3_d(y, cfg.y_in, volume_m3=vol, q_m3_per_d=q)
+    np.testing.assert_allclose(full, bio + dilution, rtol=1e-12, atol=1e-12)
+
+
+def test_hrt_days_volume_over_flow() -> None:
+    """Numeric check: V/Q coherence (example 17 m³ / 3.4 m³ d⁻¹ = 5 d)."""
+    assert hrt_days(17.0, 3.4) == pytest.approx(5.0)
+
+
+def test_cstr_from_influent_matches_si_array() -> None:
+    """Test that the CSTR configuration from influent matches the StateVector array."""
+    st = _stage6_state()
+    arr = st.to_array()
+    a = CstrContinuousConfig.from_influent(5.0, 1.0, st)
+    b = CstrContinuousConfig(5.0, 1.0, arr)
+    np.testing.assert_allclose(a.y_in, b.y_in, rtol=1e-12, atol=1e-12)

--- a/tests/unit/test_startup_batch.py
+++ b/tests/unit/test_startup_batch.py
@@ -1,0 +1,178 @@
+"""Tests for batch startup integration with evaporation (SI 17 + volume)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bioprocess_twin.core.state import StateVector, StateVectorVariant
+from bioprocess_twin.forcing import DielForcingSchedule
+from bioprocess_twin.forcing.diel_forcing_schedule import ForcingSample
+from bioprocess_twin.models.stoichiometry import N_STATE
+from bioprocess_twin.simulator import LiquidOdeRhsProblem, evaluate_liquid_ode_rhs
+from bioprocess_twin.simulator.startup_batch import (
+    StartupBatchProblem,
+    default_reasonable_startup_y0,
+    evaluate_startup_batch_rhs,
+    evaporation_rate_m3_h,
+    rain_inflow_m3_h,
+    run_startup_batch,
+    volume_derivative_m3_h,
+)
+
+
+def _rich_state() -> np.ndarray:
+    return default_reasonable_startup_y0()
+
+
+def test_evaluate_startup_rhs_matches_base_when_dVdt_zero() -> None:
+    """With E=0 and no rain, augmented derivative matches ALBA / 24 on y, dV=0."""
+    y = _rich_state()
+    v0 = 17.0
+    z = np.concatenate([y, np.array([v0])])
+    schedule = DielForcingSchedule(
+        season="summer",
+        evaporation_m3_h=0.0,
+        rain_mm_h=0.0,
+    )
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    cfg = StartupBatchProblem(
+        problem=problem,
+        startup_days=0.01,
+        y0=y,
+        volume_m3_initial=v0,
+        surface_area_m2=56.0,
+        include_rain=True,
+    )
+    t = 10.5
+    out = evaluate_startup_batch_rhs(t, z, problem_cfg=cfg)
+    base = evaluate_liquid_ode_rhs(t, y, problem=problem) / 24.0
+    assert out.shape == (N_STATE + 1,)
+    np.testing.assert_allclose(out[:N_STATE], base, rtol=1e-12, atol=1e-12)
+    assert out[-1] == pytest.approx(0.0)
+
+
+def test_concentration_term_for_evaporation_scales_with_C_over_V() -> None:
+    y = np.ones(N_STATE) * 2.0
+    v0 = 10.0
+    z = np.concatenate([y, np.array([v0])])
+    schedule = DielForcingSchedule(
+        season="summer",
+        evaporation_m3_h=0.0,
+        rain_mm_h=0.0,
+    )
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    cfg = StartupBatchProblem(
+        problem=problem,
+        startup_days=0.01,
+        y0=y,
+        volume_m3_initial=v0,
+        surface_area_m2=56.0,
+    )
+    d0 = volume_derivative_m3_h(
+        schedule.at(0.0),
+        cfg.surface_area_m2,
+        include_rain=cfg.include_rain,
+        evaporation_floor_m3_h=0.0,
+    )
+    assert d0 == pytest.approx(0.0)
+    # Force net outflow: override evaporation to a positive constant
+    sched2 = DielForcingSchedule(
+        season="summer",
+        evaporation_m3_h=0.1,
+        rain_mm_h=0.0,
+    )
+    p2 = LiquidOdeRhsProblem(schedule=sched2)
+    cfg2 = StartupBatchProblem(
+        problem=p2,
+        startup_days=0.01,
+        y0=y,
+        volume_m3_initial=v0,
+        surface_area_m2=56.0,
+    )
+    out2 = evaluate_startup_batch_rhs(0.0, z, problem_cfg=cfg2)
+    dV = out2[-1]
+    assert dV == pytest.approx(-0.1)
+    # r=0 for y=ones would not hold; compare only extra term: -(y/V)*dV
+    base2 = evaluate_liquid_ode_rhs(0.0, y, problem=p2) / 24.0
+    expected_extra = -(y / v0) * dV
+    np.testing.assert_allclose(out2[:N_STATE] - base2, expected_extra, rtol=1e-10, atol=1e-10)
+
+
+def test_run_startup_batch_shape_and_finitude() -> None:
+    y = _rich_state()
+    schedule = DielForcingSchedule(season="autumn", evaporation_m3_h=0.01, rain_mm_h=0.0)
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    cfg = StartupBatchProblem(
+        problem=problem,
+        startup_days=0.5,
+        y0=y,
+        volume_m3_initial=17.0,
+        surface_area_m2=56.0,
+        include_rain=False,
+    )
+    res = run_startup_batch(cfg, t_eval_hours=np.linspace(0.0, 12.0, 5))
+    assert res.y.shape[1] == N_STATE
+    assert res.volume_m3.shape[0] == res.t_hours.shape[0]
+    assert np.all(np.isfinite(res.y))
+    assert np.all(np.isfinite(res.volume_m3))
+    assert res.y.shape[0] == 5
+
+
+def test_volume_decreases_with_evaporation_no_rain() -> None:
+    y = _rich_state()
+    schedule = DielForcingSchedule(
+        season="summer",
+        evaporation_m3_h=0.02,
+        rain_mm_h=0.0,
+    )
+    problem = LiquidOdeRhsProblem(schedule=schedule)
+    v0 = 100.0
+    cfg = StartupBatchProblem(
+        problem=problem,
+        startup_days=1.0,
+        y0=y,
+        volume_m3_initial=v0,
+        surface_area_m2=56.0,
+        include_rain=False,
+    )
+    res = run_startup_batch(cfg, t_eval_hours=np.array([0.0, 6.0, 12.0]))
+    assert res.volume_m3[-1] < res.volume_m3[0]
+
+
+def test_evaporation_floor_increases_loss_when_schedule_zero() -> None:
+    sample = ForcingSample(
+        t_hours=0.0,
+        temperature_C=20.0,
+        irradiance_umol_m2_s=0.0,
+        evaporation_m3_h=0.0,
+        rain_mm_h=None,
+    )
+    assert evaporation_rate_m3_h(sample, evaporation_floor_m3_h=1e-6) == pytest.approx(1e-6)
+    s2 = ForcingSample(
+        t_hours=0.0,
+        temperature_C=20.0,
+        irradiance_umol_m2_s=0.0,
+        evaporation_m3_h=0.05,
+        rain_mm_h=None,
+    )
+    assert evaporation_rate_m3_h(s2, evaporation_floor_m3_h=1e-6) == pytest.approx(0.05)
+
+
+def test_rain_inflow_mm_to_m3() -> None:
+    sample = ForcingSample(
+        t_hours=0.0,
+        temperature_C=20.0,
+        irradiance_umol_m2_s=0.0,
+        evaporation_m3_h=0.0,
+        rain_mm_h=2.0,
+    )
+    q = rain_inflow_m3_h(sample, surface_area_m2=1000.0, include_rain=True)
+    assert q == pytest.approx(2.0)
+
+
+def test_default_reasonable_startup_y0_length_and_nonneg() -> None:
+    y = default_reasonable_startup_y0()
+    assert y.shape == (N_STATE,)
+    assert np.all(y >= 0.0)
+    StateVector.from_array(y, variant=StateVectorVariant.SI)


### PR DESCRIPTION
## Summary

Adds **open-pond startup integration** with rain/evaporation-driven volume, **pure CSTR dilution helpers**, and **optional dilution on the Stage 6 liquid ODE**—either **constant** hydraulic/influent parameters or **schedule-linked** flow from `DielForcingSchedule.inflow_m3_h`, with optional **callable** influent on the daily clock.

## Startup batch (`startup_batch`)

- Augmented state: **17 SI components + volume** `[m³]`.
- Volume ODE: **`dV/dt = Q_rain − E`** from `ForcingSample` (`DielForcingSchedule.at`), with **`include_rain`**, **`evaporation_floor_m3_h`**, and terminal event at **`volume_minimum_m3`**.
- Concentrations: **`evaluate_liquid_ode_rhs`** (rates **g m⁻³ d⁻¹** scaled to **per hour**) plus lumped term **`−(C/V)·dV/dt`** for variable volume.
- **`run_startup_batch`**: `solve_ivp` (default LSODA), documented tolerances / step cap.

## phase1-04c-A (`cstr_transport`)

- NumPy-only: **`cstr_dilution_rate_g_m3_d`**, **`hrt_days`**, **`q_m3_per_day_from_hrt_days`**, **`q_m3_per_day_from_m3_per_hour`** (consistent **m³ d⁻¹** / **m³** / **m³ h⁻¹**).
- Unit tests: zeros, shape, HRT, tracer-style component, **no** liquid RHS import.

## phase1-04c-B (`liquid_ode_rhs`)

- **`CstrContinuousConfig`** (`V`, `Q` **m³ d⁻¹**, SI **`y_in`**).
- **`LiquidOdeRhsProblem.cstr`**: optional; **`None`** ⇒ same behaviour as pre-transport ODE wrapper (**phase1-04b**).
- **`evaluate_liquid_ode_rhs`**: bio RHS + **`cstr_dilution_rate_g_m3_d`** when configured.

## phase1-04c-C (`liquid_ode_rhs`)

- **`CstrScheduleFlowConfig`** + **`CstrTransportConfig`** union.
- **`q_m3_per_d`** from **`ForcingSample.inflow_m3_h`** (same **`schedule.at`** as kinetics); missing inflow ⇒ zero dilution.
- **`effective_y_in_schedule`** for constant or **callable** influent (**wrapped** clock **`[0, 24)`**).

## Package surface

- **`simulator/__init__.py`**: exports CSTR helpers and config types.

## Tests & docs

- **`tests/unit/test_cstr_transport.py`**, **`tests/unit/test_liquid_ode_rhs.py`**, **`tests/unit/test_startup_batch.py`** (as applicable).
- **`docs/development/DEVLOG.md`**: sprint notes for **phase1-04c (A–C)**.

Closes #20 